### PR TITLE
Use hono tiny preset

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -79,6 +79,14 @@
         "noNestedTernary": "error",
         "noParameterAssign": "error",
         "noParameterProperties": "error",
+        "noRestrictedImports": {
+          "level": "error",
+          "options": {
+            "paths": {
+              "@hono/hono": "Use `@hono/hono/tiny` instead"
+            }
+          }
+        },
         "noSubstr": "error",
         "noUnusedTemplateLiteral": "error",
         "noUselessElse": "error",

--- a/deno.lock
+++ b/deno.lock
@@ -16,7 +16,7 @@
     "npm:@jsr/std__streams@^1.0.16": "1.0.16",
     "npm:@jsr/std__ulid@1": "1.0.0",
     "npm:@types/node@^25.0.3": "25.0.3",
-    "npm:arkenv@~0.8.2": "0.8.2_arktype@2.1.29",
+    "npm:arkenv@~0.8.3": "0.8.3_arktype@2.1.29",
     "npm:arktype@^2.1.29": "2.1.29",
     "npm:hono-openapi@^1.1.2": "1.1.2_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__arktype@2.1.29__quansync@0.2.11_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___arktype@2.1.29___quansync@0.2.11__@standard-schema+spec@1.1.0__arktype@2.1.29__openapi-types@12.1.3__@types+json-schema@7.0.15_@types+json-schema@7.0.15_openapi-types@12.1.3_arktype@2.1.29",
     "npm:nanoid@^5.1.6": "5.1.6",
@@ -313,8 +313,8 @@
         "undici-types"
       ]
     },
-    "arkenv@0.8.2_arktype@2.1.29": {
-      "integrity": "sha512-FD5p4G0TcgeFXm6aMDEUVGd1hL6Hytz8bzynnwTXkwQ1s9QZPGKZiZHq6H7G0tWx/UryvgE5QNFp1S7eWU5lKQ==",
+    "arkenv@0.8.3_arktype@2.1.29": {
+      "integrity": "sha512-fndPYpIZ/EvARTXabWG5H+gKxlJEbPgTRvXH8htimmCbdBfEXZsSOgObwdiCCCcBz33tJAYk88goDtj0Ao99NA==",
       "dependencies": [
         "arktype"
       ]
@@ -400,7 +400,7 @@
         "npm:@jsr/std__streams@^1.0.16",
         "npm:@jsr/std__ulid@1",
         "npm:@types/node@^25.0.3",
-        "npm:arkenv@~0.8.2",
+        "npm:arkenv@~0.8.3",
         "npm:arktype@^2.1.29",
         "npm:hono-openapi@^1.1.2",
         "npm:nanoid@^5.1.6",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@std/streams": "npm:@jsr/std__streams@^1.0.16",
     "@std/ulid": "npm:@jsr/std__ulid@^1.0.0",
     "@types/node": "npm:@types/node@^25.0.3",
-    "arkenv": "npm:arkenv@~0.8.2",
+    "arkenv": "npm:arkenv@~0.8.3",
     "arktype": "npm:arktype@^2.1.29",
     "biome": "npm:@biomejs/biome@2.3.11",
     "nanoid": "npm:nanoid@^5.1.6",

--- a/src/endpoints/document/v1/delete.ts
+++ b/src/endpoints/document/v1/delete.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, validator } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/document/v1/get.ts
+++ b/src/endpoints/document/v1/get.ts
@@ -1,5 +1,5 @@
-import { Hono } from "@hono/hono";
 import { stream } from "@hono/hono/streaming";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { decodeTime } from "@std/ulid";
 import { type } from "arktype";

--- a/src/endpoints/document/v1/index.ts
+++ b/src/endpoints/document/v1/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import type { Env } from "#http/type.ts";
 import delete_ from "./delete.ts";
 import get from "./get.ts";

--- a/src/endpoints/document/v1/patch.ts
+++ b/src/endpoints/document/v1/patch.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/document/v1/post.ts
+++ b/src/endpoints/document/v1/post.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { monotonicUlid } from "@std/ulid";
 import { type } from "arktype";

--- a/src/endpoints/legacy/v2/documents/access.route.ts
+++ b/src/endpoints/legacy/v2/documents/access.route.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { toText } from "@std/streams";
 import { type } from "arktype";

--- a/src/endpoints/legacy/v2/documents/accessRaw.route.ts
+++ b/src/endpoints/legacy/v2/documents/accessRaw.route.ts
@@ -1,5 +1,5 @@
-import { Hono } from "@hono/hono";
 import { stream } from "@hono/hono/streaming";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/legacy/v2/documents/edit.route.ts
+++ b/src/endpoints/legacy/v2/documents/edit.route.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/legacy/v2/documents/exists.route.ts
+++ b/src/endpoints/legacy/v2/documents/exists.route.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/legacy/v2/documents/index.ts
+++ b/src/endpoints/legacy/v2/documents/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import type { Env } from "#http/type.ts";
 import access from "./access.route.ts";
 import accessRaw from "./accessRaw.route.ts";

--- a/src/endpoints/legacy/v2/documents/publish.route.ts
+++ b/src/endpoints/legacy/v2/documents/publish.route.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { monotonicUlid } from "@std/ulid";
 import { type } from "arktype";

--- a/src/endpoints/legacy/v2/documents/remove.route.ts
+++ b/src/endpoints/legacy/v2/documents/remove.route.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver, validator } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/user/v1/create.ts
+++ b/src/endpoints/user/v1/create.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import { describeRoute, resolver } from "@hono/openapi";
 import { type } from "arktype";
 import { constant, mutable } from "#/global.ts";

--- a/src/endpoints/user/v1/index.ts
+++ b/src/endpoints/user/v1/index.ts
@@ -1,4 +1,4 @@
-import { Hono } from "@hono/hono";
+import { Hono } from "@hono/hono/tiny";
 import type { Env } from "#http/type.ts";
 import create from "./create.ts";
 

--- a/src/http/router.ts
+++ b/src/http/router.ts
@@ -1,6 +1,6 @@
-import { Hono } from "@hono/hono";
 import { cors } from "@hono/hono/cors";
 import { HTTPException } from "@hono/hono/http-exception";
+import { Hono } from "@hono/hono/tiny";
 import { openAPIRouteHandler } from "@hono/openapi";
 import { v1DocumentRouter } from "#endpoint/document/v1/index.ts";
 import { v2LegacyDocumentRouter } from "#endpoint/legacy/v2/documents/index.ts";


### PR DESCRIPTION
Since we don't have many endpoints registered, the gains of using the "normal preset" are not noticeable. Instead, when using the “tiny preset", we get somewhat more consistent raw performance and shave off 7kb from the dist bundle.

Bench (document "babbaa" doesn't exist):
```
oha -z 10s --no-tui --disable-compression --http-version=1.1 -m HEAD http://localhost:4000/api/document/v1/babbaa
```

"@hono/hono" preset:
```
Summary:
  Total:	10001.8267 ms
  Slowest:	21.9691 ms
  Fastest:	1.2720 ms
  Average:	2.0374 ms
  Requests/sec:	24524.4201

Response time histogram:
   1.272 ms [1]      |
   3.342 ms [233405] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
   5.411 ms [11611]  |■
   7.481 ms [38]     |
   9.551 ms [134]    |
  11.621 ms [0]      |
  13.690 ms [0]      |
  15.760 ms [0]      |
  17.830 ms [25]     |
  19.899 ms [10]     |
  21.969 ms [15]     |
```

"@hono/hono/tiny" preset:
```
Summary:
  Total:	10002.1501 ms
  Slowest:	9.2341 ms
  Fastest:	1.0291 ms
  Average:	1.9588 ms
  Requests/sec:	25507.3155

Response time histogram:
  1.029 ms [1]      |
  1.850 ms [174855] |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  2.670 ms [41987]  |■■■■■■■
  3.491 ms [29361]  |■■■■■
  4.311 ms [8299]   |■
  5.132 ms [470]    |
  5.952 ms [9]      |
  6.773 ms [46]     |
  7.593 ms [1]      |
  8.414 ms [10]     |
  9.234 ms [40]     |
```

Using ratelimited 100/rpq makes no difference:
```
oha -q 100 --no-tui --disable-compression --http-version=1.1 -m HEAD http://localhost:4000/api/document/v1/babbaa
```

See: https://hono.dev/docs/concepts/routers
See: https://hono.dev/docs/api/presets